### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/CodeChange.Toolkit.AspNetCore/CodeChange.Toolkit.AspNetCore.csproj
+++ b/src/CodeChange.Toolkit.AspNetCore/CodeChange.Toolkit.AspNetCore.csproj
@@ -15,7 +15,15 @@
     <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <PackageReleaseNotes></PackageReleaseNotes>
     <Tags>CodeChange Toolkit WebApi Web API .NET Core DOTNET AspNetCore C#</Tags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />

--- a/src/CodeChange.Toolkit.Autofac/CodeChange.Toolkit.Autofac.csproj
+++ b/src/CodeChange.Toolkit.Autofac/CodeChange.Toolkit.Autofac.csproj
@@ -16,7 +16,15 @@
     <PackageReleaseNotes>Implemented ITypeActivator interface</PackageReleaseNotes>
     <Tags>CodeChange Toolkit Autofac .NET DOTNET C#</Tags>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
   </ItemGroup>

--- a/src/CodeChange.Toolkit.Azure/CodeChange.Toolkit.Azure.csproj
+++ b/src/CodeChange.Toolkit.Azure/CodeChange.Toolkit.Azure.csproj
@@ -17,7 +17,15 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Tags>CodeChange Toolkit Azure .NET DOTNET C#</Tags>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0" />

--- a/src/CodeChange.Toolkit.Domain/CodeChange.Toolkit.Domain.csproj
+++ b/src/CodeChange.Toolkit.Domain/CodeChange.Toolkit.Domain.csproj
@@ -17,7 +17,15 @@
     <PackageReleaseNotes>Added WebAddress value object.</PackageReleaseNotes>
     <Tags>CodeChange Toolkit Domain DDD .NET DOTNET C#</Tags>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="2.3.0" />
   </ItemGroup>

--- a/src/CodeChange.Toolkit.EF6/CodeChange.Toolkit.EF6.csproj
+++ b/src/CodeChange.Toolkit.EF6/CodeChange.Toolkit.EF6.csproj
@@ -16,7 +16,15 @@
     <PackageReleaseNotes>Converted project to .NET Standard 2.1</PackageReleaseNotes>
     <Tags>CodeChange Toolkit Domain EF6 EntityFramework .NET DOTNET C#</Tags>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Humanizer.Core" Version="2.7.9" />

--- a/src/CodeChange.Toolkit.EntityFrameworkCore/CodeChange.Toolkit.EntityFrameworkCore.csproj
+++ b/src/CodeChange.Toolkit.EntityFrameworkCore/CodeChange.Toolkit.EntityFrameworkCore.csproj
@@ -17,7 +17,15 @@
     <PackageReleaseNotes>Updated RepositoryBase to work with new DateRange Value Object.</PackageReleaseNotes>
     <Tags>CodeChange Toolkit .NET DOTNET ENTITY FRAMEWORK CORE C#</Tags>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="2.3.0" />
     <PackageReference Include="Humanizer.Core" Version="2.7.9" />

--- a/src/CodeChange.Toolkit.Persistence/CodeChange.Toolkit.Persistence.csproj
+++ b/src/CodeChange.Toolkit.Persistence/CodeChange.Toolkit.Persistence.csproj
@@ -16,5 +16,13 @@
     <PackageReleaseNotes>Added cancellation token support.</PackageReleaseNotes>
     <Tags>CodeChange Toolkit Persistence .NET DOTNET C#</Tags>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/src/CodeChange.Toolkit.WebApi/CodeChange.Toolkit.WebApi.csproj
+++ b/src/CodeChange.Toolkit.WebApi/CodeChange.Toolkit.WebApi.csproj
@@ -16,7 +16,16 @@
 		<PackageReleaseNotes>Added support to WebApiPuginBase for protocol errors.</PackageReleaseNotes>
 		<Tags>CodeChange Toolkit WebApi Web API .NET DOTNET C#</Tags>
 		<LangVersion>7.1</LangVersion>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
 		<PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />

--- a/src/CodeChange.Toolkit/CodeChange.Toolkit.csproj
+++ b/src/CodeChange.Toolkit/CodeChange.Toolkit.csproj
@@ -16,7 +16,15 @@
     <PackageReleaseNotes>Created synchronous and asynchronous paged collections.</PackageReleaseNotes>
     <Tags>CodeChange Toolkit .NET DOTNET C#</Tags>
     <LangVersion>7.1</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
